### PR TITLE
workaround `c.Request.RequestURI` being empty

### DIFF
--- a/api/vercel.go
+++ b/api/vercel.go
@@ -23,9 +23,17 @@ var (
 // @host golang-vercel.vercel.app
 func init() {
 	app = gin.New()
-	app.GET("/doc/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
+	app.GET("/doc/*any", FixRequestUri)
 	app.GET("/ping", Ping)
 	app.GET("/hello/:name", Hello)
+}
+
+func FixRequestUri(c *gin.Context) {
+	if c.Request.RequestURI == "" {
+		c.Request.RequestURI = c.Request.URL.Path
+	}
+
+	ginSwagger.WrapHandler(swaggerFiles.Handler)(c)
 }
 
 // Entrypoint

--- a/public/index.html
+++ b/public/index.html
@@ -88,8 +88,8 @@
     <div>
         <p><b>CLICK TO PLAY</b></p>
         <p><a href="/ping">Ping Pong</a></p>
-        <p><a href="/api/hello/rdhawladar">Hello Clap</a></p>
-        <p><a href="/api/doc/index.html">Swagger File</a></p>
+        <p><a href="/hello/rdhawladar">Hello Clap</a></p>
+        <p><a href="/doc/index.html">Swagger File</a></p>
         <p><a href="https://github.com/rdhawladar/golang-vercel">GitHub Link</a></p>
     </div>
 </body>


### PR DESCRIPTION
Workaround an issue where `c.Request.RequestURI` is sometimes empty.

I deployed this and it appears to be working.